### PR TITLE
fixed: no handling empty table while recursive split

### DIFF
--- a/lua/treesj/treesj/utils.lua
+++ b/lua/treesj/treesj/utils.lua
@@ -166,7 +166,9 @@ function M._split(tsj)
           _merge_text_to_prev(lines, spacing, text[1])
           table.remove(text, 1)
         end
-        table.insert(lines, text)
+        if not vim.tbl_isempty(text) then
+          table.insert(lines, text)
+        end
       end
     else
       _set_whitespace(child:text())

--- a/tests/langs/javascript_recursive_spec.lua
+++ b/tests/langs/javascript_recursive_spec.lua
@@ -48,6 +48,16 @@ local data_for_split = {
     result = { 18, 27 },
     settings = settings,
   },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "statement_block", preset with recursive = true',
+    cursor = { 33, 1 },
+    expected = { 35, 40 },
+    result = { 32, 37 },
+    settings = settings,
+  },
 }
 
 describe('TreeSJ SPLIT:', function()

--- a/tests/langs/javascript_spec.lua
+++ b/tests/langs/javascript_spec.lua
@@ -125,6 +125,16 @@ local data_for_split = {
     result = { 98, 103 },
     settings = {},
   },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "statement_block", preset default',
+    cursor = { 109, 1 },
+    expected = { 111, 116 },
+    result = { 108, 113 },
+    settings = {},
+  },
 }
 
 local data_for_join = {
@@ -226,6 +236,16 @@ local data_for_join = {
     cursor = { 103, 12 },
     expected = { 98, 99 },
     result = { 101, 102 },
+    settings = {},
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "statement_block" (if with return), preset default',
+    cursor = { 112, 1 },
+    expected = { 108, 109 },
+    result = { 111, 112 },
     settings = {},
   },
 }

--- a/tests/sample/index.js
+++ b/tests/sample/index.js
@@ -104,3 +104,13 @@ export {
   sub,
   reducer,
 };
+
+// RESULT OF JOIN (node "statement_block", preset default)
+if (b <= a) { 1 + 2; add(2, 1) + sum(2, 1); return (console.log(1), 1) >= 1; }
+
+// RESULT OF SPLIT (node "statement_block", preset default)
+if (b <= a) {
+  1 + 2;
+  add(2, 1) + sum(2, 1);
+  return (console.log(1), 1) >= 1;
+}

--- a/tests/sample/index_recursive.js
+++ b/tests/sample/index_recursive.js
@@ -28,3 +28,14 @@ function trycatch(test) {
     console.log('Done!');
   }
 }
+
+// RESULT OF JOIN (node "statement_block", preset default)
+if (b <= a) { 1 + 2; add(2, 1) + sum(2, 1); return (console.log(1), 1) >= 1; }
+
+// RESULT OF SPLIT (node "statement_block", preset default)
+if (b <= a) {
+  1 + 2;
+  add(2, 1) + sum(2, 1);
+  return (console.log(1), 1) >= 1;
+}
+


### PR DESCRIPTION
Fixed no handling empty table while recursive split and added tests for this case.