### PR TITLE
feat: add python support

### DIFF
--- a/lua/treesj/langs/python.lua
+++ b/lua/treesj/langs/python.lua
@@ -1,0 +1,13 @@
+local treesj_utils = require('treesj.langs.utils')
+
+return {
+    parameters = treesj_utils.set_preset_for_args(),
+    argument_list = treesj_utils.set_preset_for_args(),
+    list = treesj_utils.set_preset_for_list(),
+    set = treesj_utils.set_preset_for_list(),
+    tuple = treesj_utils.set_preset_for_list(),
+    dictionary = treesj_utils.set_preset_for_dict({ both = { last_separator = false }}),
+
+    assignment = { target_nodes = { 'list', 'set', 'tuple', 'dictionary' } },
+    call = { target_nodes = { 'argument_list' } },
+}


### PR DESCRIPTION
adds support for Python, to a fairly usable extent. Things which are simple, yet cumbersome.
Handles common constructs. Refer to TS Documentation for reference.
This shall provide decent enough functionality to start with. Any future additions will only add value.

TODO: add tests