### PR TITLE
Keymap descriptions

### DIFF
--- a/lua/treesj/settings.lua
+++ b/lua/treesj/settings.lua
@@ -80,7 +80,7 @@ M._set_default_keymaps = function()
   if M.settings and M.settings.use_default_keymaps then
     local treesj = require('treesj')
     for _, cmd in ipairs(commands) do
-      vim.keymap.set(cmd.mode, cmd.keys, treesj[cmd.func])
+      vim.keymap.set(cmd.mode, cmd.keys, treesj[cmd.func], { desc = cmd.desc })
     end
   end
 end


### PR DESCRIPTION
Hi! I've notice that the keymap descriptions were defined for the command config but not passed to the keymaps. When using the default config and leader menu, the key would appear, but not the description.  

Here's an example in LazyVim : 
![image](https://user-images.githubusercontent.com/6100619/213071080-bce3aae2-6dd2-4b8d-a890-ca205e30a972.png)

A quickfix is to reuse the command description, which seems just fine. Could also be something shorter like _Split/Join_ for the toggle? I just thought that would be nice to have something there, out of the box.

Great plugin by way! Seems very useful and enjoyable so far!