### PR TITLE
Determine the effective shiftwidth with `shiftwidth()`

### DIFF
--- a/lua/treesj/treesj/init.lua
+++ b/lua/treesj/treesj/init.lua
@@ -69,7 +69,7 @@ function TreeSJ:build_tree()
     end
 
     if not tsj:is_ignore('split') and tsj:has_preset() then
-      local sw = vim.api.nvim_buf_get_option(0, 'shiftwidth')
+      local sw = vim.fn.shiftwidth()
       tsj._root_indent = tsj:get_prev_indent() + sw
     end
 

--- a/lua/treesj/utils.lua
+++ b/lua/treesj/utils.lua
@@ -365,7 +365,7 @@ function M.calc_indent(tsj)
 
   local pp = parent:preset('split')
   local sratr_indent = parent._root_indent
-  local shiftwidth = vim.api.nvim_buf_get_option(0, 'shiftwidth')
+  local shiftwidth = vim.fn.shiftwidth()
   local common_indent = sratr_indent + shiftwidth
   local is_last = is_last_no_omit(tsj) and pp.last_indent == 'normal'
 


### PR DESCRIPTION
When `shiftwidth` is zero, the `tabstop` value is used for indentation and does not `vim.api.nvim_get_buf_option(0,  shiftwidth')` return the effective value.  Hence, use `shiftwidth()`.

Fixes #45 