### PR TITLE
Added option for set inner indents like first indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,13 @@ local somenode = {
 
     -- string: Which indent must be on the last line of the formatted node.
     -- 'normal' – indent equals of the indent from first line;
-    -- 'inner' – indent, like all inner nodes.
+    -- 'inner' – indent, like all inner nodes (indent of start line of node + vim.fn.shiftwidth()).
+
     last_indent = 'normal',
+    -- string: Which indent must be on the last line of the formatted node.
+    -- 'normal' – indent equals of the indent from first line;
+    -- 'inner' – indent, like all inner nodes (indent of start line of node + vim.fn.shiftwidth()).
+    inner_indent = 'inner',
   },
   -- If 'true', node will be completely removed from langs preset
   disable = false,

--- a/lua/treesj/langs/default_preset.lua
+++ b/lua/treesj/langs/default_preset.lua
@@ -56,8 +56,12 @@ return {
     recursive_ignore = {},
     -- string: Which indent must be on the last line of the formatted node.
     -- 'normal' – indent equals of the indent from first line;
-    -- 'inner' – indent, like all inner nodes.
+    -- 'inner' – indent, like all inner nodes (indent of start line of node + vim.fn.shiftwidth()).
     last_indent = 'normal',
+    -- string: Which indent must be on the last line of the formatted node.
+    -- 'normal' – indent equals of the indent from first line;
+    -- 'inner' – indent, like all inner nodes.
+    inner_indent = 'inner',
   },
   -- If 'true', node will be completely removed from langs preset
   disable = false,

--- a/lua/treesj/utils.lua
+++ b/lua/treesj/utils.lua
@@ -369,8 +369,9 @@ function M.calc_indent(tsj)
   local shiftwidth = vim.fn.shiftwidth()
   local common_indent = start_indent + shiftwidth
   local is_last = is_last_no_omit(tsj) and pp.last_indent == 'normal'
+  local is_same = pp.inner_indent == 'normal'
 
-  return is_last and start_indent or common_indent
+  return (is_last or is_same) and start_indent or common_indent
 end
 
 ---Get base nodes for first/last imitator node in non-bracket blocks


### PR DESCRIPTION
Some languages using first indent's value for inner indents.

Option `split.inner_indent` adds support for this case.

E.g.,
```javascript
// from
let a = [ 1, 2 ];
// to
let a = [
1,
2,
];
// insted of normal
let a = [
  1,
  2,
];
```