### PR TITLE
fix(utils): properly check lines datatype

### DIFF
--- a/lua/treesj/utils.lua
+++ b/lua/treesj/utils.lua
@@ -180,12 +180,15 @@ function M.collect_children(node, filter)
 end
 
 ---Return text of node
----@param node userdata TSNode instance
+---@param node TSNode from userdata
 ---@return string
 function M.get_node_text(node)
   local lines = query.get_node_text(node, 0, { concat = false })
   local trimed_lines = {}
   local sep = ' '
+  if type(lines) == 'string' then
+    lines = vim.split(lines, '\n')
+  end
   for _, line in ipairs(lines) do
     line = vim.trim(line)
     if not M.is_empty(line) then


### PR DESCRIPTION
Updating nightly beyond [this PR](https://github.com/neovim/neovim/pull/22613) causes an error with this plugin. This PR fixes that as from now on, lines will always be a string - we can convert it to a table by splitting on newline. However, once 0.9 is stable this should be refactored again to only consider it as a string, not as a string or table

