### PR TITLE
refactor!: remove nvim-treesitter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://github.com/Wansmer/treesj/assets/46977173/4277455b-81fd-4e99-9af7-43c77d
 
 ## Requirements
 
-- [Neovim 0.8+](https://github.com/neovim/neovim/releases)
+- [Neovim 0.9+](https://github.com/neovim/neovim/releases)
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 
 ## Installation

--- a/lua/treesj/notify.lua
+++ b/lua/treesj/notify.lua
@@ -11,7 +11,6 @@ M.msg = {
   contains_error = 'The node "%s" or its descendants contain a syntax error and cannot be %s',
   no_configured_node = 'Node "%s" for lang "%s" is not configured',
   no_contains_target_node = 'Node "%s" has no contains descendants for split/join',
-  ts_not_found = 'Nvim-treesitter not found. TreeSJ required treesitter for work.',
   no_format_with = 'Cannot %s "%s" containing node from one of this: %s',
   extra_longer = 'Cannot "join" node longer than %s symbols. Check your settings to change it.',
   version_not_support = 'Current version of neovim is "0.%s". TreeSJ requires version "0.8" or higher',

--- a/lua/treesj/search.lua
+++ b/lua/treesj/search.lua
@@ -3,21 +3,23 @@ local langs = require('treesj.settings').settings.langs
 local u = require('treesj.utils')
 local msg = notify.msg
 
-local ts_ok, parsers = pcall(require, 'nvim-treesitter.parsers')
-if not ts_ok then
-  notify.error(msg.ts_not_found)
-  return
-end
-
 local M = {}
 
----Get lunguage for node
+---Get language for node
 ---@param node TSNode TSNode instance
 ---@return string
 local function get_node_lang(node)
   local range = { node:range() }
-  local lang_tree = parsers.get_parser()
-  local current_tree = lang_tree:language_for_range(range)
+  local buf = vim.api.nvim_get_current_buf()
+  local ok, parser = pcall(
+    vim.treesitter.get_parser,
+    buf,
+    vim.treesitter.language.get_lang(vim.bo[buf].ft)
+  )
+  if not ok then
+    return ''
+  end
+  local current_tree = parser:language_for_range(range)
   return current_tree:lang()
 end
 


### PR DESCRIPTION
the plugin functionality is deprecated for the 1.0 rewrite, you can read more in the `main` branch's readme (note, default is master)

This does raise the neovim requirement to 0.9.0