### PR TITLE
Ruby `unless`

### DIFF
--- a/lua/treesj/langs/ruby.lua
+++ b/lua/treesj/langs/ruby.lua
@@ -119,20 +119,20 @@ return {
       space_in_brackets = true,
       format_tree = function(tsj)
         if tsj:child('else') then
-          local if_ = tsj:child('unless')
+          local unless_ = tsj:child('unless')
           local else_ = tsj:child('else')
           if else_:has_to_format() then
             local text = else_:child(1):text()
-            else_:child(1):update_text(text:gsub('^else', ':'))
+            else_:child(1):update_text(text:gsub('^else', '?'))
           else
             local text = else_:text()
-            else_:update_text(text:gsub('^else', ':'))
+            else_:update_text(text:gsub('^else', '?'))
           end
-          if_:update_text('? ')
-          tsj:update_children({ tsj:child(2), if_, tsj:child('then'), else_ })
+          unless_:update_text(': ')
+          tsj:update_children({ tsj:child(2), else_, unless_, tsj:child('then') })
         else
-          local if_node = tsj:child('unless')
-          tsj:update_children({ tsj:child('then'), if_node, if_node:next() })
+          local unless_node = tsj:child('unless')
+          tsj:update_children({ tsj:child('then'), unless_node, unless_node:next() })
         end
       end,
     },

--- a/lua/treesj/langs/ruby.lua
+++ b/lua/treesj/langs/ruby.lua
@@ -58,6 +58,17 @@ return {
       end,
     },
   }),
+  unless_modifier = lang_utils.set_default_preset({
+    join = { enable = false },
+    split = {
+      omit = { lang_utils.helpers.if_second },
+      format_tree = function(tsj)
+        local if_node = tsj:child('unless')
+        local end_ = tsj:create_child({ text = 'end', type = 'end' })
+        tsj:update_children({ if_node, if_node:next(), tsj:child(1), end_ })
+      end,
+    },
+  }),
   ['if'] = lang_utils.set_default_preset({
     split = { enable = false },
     join = {
@@ -87,6 +98,40 @@ return {
           tsj:update_children({ tsj:child(2), if_, tsj:child('then'), else_ })
         else
           local if_node = tsj:child('if')
+          tsj:update_children({ tsj:child('then'), if_node, if_node:next() })
+        end
+      end,
+    },
+  }),
+  ['unless'] = lang_utils.set_default_preset({
+    split = { enable = false },
+    join = {
+      enable = function(tsn)
+        local check = {
+          tsn:field('consequence')[1],
+          tsn:field('alternative')[1],
+        }
+
+        return utils.every(check, function(el)
+          return not el and true or el:named_child_count() == 1
+        end)
+      end,
+      space_in_brackets = true,
+      format_tree = function(tsj)
+        if tsj:child('else') then
+          local if_ = tsj:child('unless')
+          local else_ = tsj:child('else')
+          if else_:has_to_format() then
+            local text = else_:child(1):text()
+            else_:child(1):update_text(text:gsub('^else', ':'))
+          else
+            local text = else_:text()
+            else_:update_text(text:gsub('^else', ':'))
+          end
+          if_:update_text('? ')
+          tsj:update_children({ tsj:child(2), if_, tsj:child('then'), else_ })
+        else
+          local if_node = tsj:child('unless')
           tsj:update_children({ tsj:child('then'), if_node, if_node:next() })
         end
       end,

--- a/tests/langs/ruby/join_spec.lua
+++ b/tests/langs/ruby/join_spec.lua
@@ -112,6 +112,15 @@ local data_for_join = {
     expected = { 119, 120 },
     result = { 122, 123 },
   },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "unless to conditional", preset default',
+    cursor = { 131, 1 },
+    expected = { 127, 128 },
+    result = { 130, 131 },
+  },
 }
 
 local treesj = require('treesj')

--- a/tests/langs/ruby/join_spec.lua
+++ b/tests/langs/ruby/join_spec.lua
@@ -103,6 +103,15 @@ local data_for_join = {
     expected = { 108, 109 },
     result = { 113, 114 },
   },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "unless to unless_modifier", preset default',
+    cursor = { 123, 1 },
+    expected = { 119, 120 },
+    result = { 122, 123 },
+  },
 }
 
 local treesj = require('treesj')

--- a/tests/langs/ruby/split_spec.lua
+++ b/tests/langs/ruby/split_spec.lua
@@ -103,6 +103,15 @@ local data_for_split = {
     expected = { 113, 116 },
     result = { 108, 111 },
   },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "unless_modifier to unless", preset default',
+    cursor = { 120, 5 },
+    expected = { 122, 125 },
+    result = { 119, 122 },
+  },
 }
 
 local treesj = require('treesj')

--- a/tests/sample/index.rb
+++ b/tests/sample/index.rb
@@ -123,3 +123,13 @@ return false unless true
 unless true
   return false
 end
+
+# RESULT OF JOIN (node "conditional to unless", preset default)
+cond ? do_that('cond') : do_this('not nond')
+
+# RESULT OF SPLIT (node "unless to conditional", preset default)
+unless cond
+  do_this('not nond')
+else
+  do_that('cond')
+end

--- a/tests/sample/index.rb
+++ b/tests/sample/index.rb
@@ -115,3 +115,11 @@ def config
     method
   end
 end
+
+# RESULT OF JOIN (node "unless_modifier to unless", preset default)
+return false unless true
+
+# RESULT OF SPLIT (node "unless to unless_modifier", preset default)
+unless true
+  return false
+end


### PR DESCRIPTION
Ruby has syntactic sugar for `if not` in the form of `unless`, so I figured I'd take a stab at it:

```rb
# RESULT OF JOIN (node "unless_modifier to unless", preset default)
return false unless true

# RESULT OF SPLIT (node "unless to unless_modifier", preset default)
unless true
  return false
end
```

I literally copied and pasted the logic for `if` as I didn't want to make any assumptions on how (and _if_) you wanted to consolidate anything, please feel free to modify it as you please and I'm open to change anything you'd like to do differently.

Thank you!