### PR TITLE
Fix: usage in macros

### DIFF
--- a/lua/treesj/init.lua
+++ b/lua/treesj/init.lua
@@ -22,7 +22,7 @@ end
 
 local function set_opfunc_and_format(dir)
   vim.opt.operatorfunc = "v:lua.require'treesj'.__" .. dir
-  vim.api.nvim_feedkeys('g@l', 'nx', true)
+  vim.api.nvim_feedkeys('g@l', 'nix', true)
 end
 
 local function format(data)


### PR DESCRIPTION
`nvim_feedkeys` should be used with the `insert` flag to be handled right in macros. Otherwise, these keys will be handled at the end of the macro, and the sequences of the keys will be broken.

You can check it by splitting or joining several nodes:
- Start a recording macro
- Join a node
- Move to a next open node
- Join the node
- Stop recording macro

Then try to use the macro on the restored nodes or on a new pair of nodes with the same relative location.