### PR TITLE
Feat: don't change text if nothing to do

### DIFF
--- a/lua/treesj/format.lua
+++ b/lua/treesj/format.lua
@@ -150,6 +150,11 @@ function M._format(mode, override)
   cursor:compute(treesj, MODE)
   local new_cursor = cursor:get_cursor()
 
+  local initial_text = vim.api.nvim_buf_get_text(0, sr, sc, er, ec, {})
+  if vim.deep_equal(initial_text, replacement) then
+    return
+  end
+
   local insert_ok, e =
     pcall(vim.api.nvim_buf_set_text, 0, sr, sc, er, ec, replacement)
 

--- a/lua/treesj/format.lua
+++ b/lua/treesj/format.lua
@@ -107,16 +107,16 @@ function M._format(mode, override)
     end
   end
 
+  if type(p.fallback) == 'function' then
+    p.fallback(tsn_data.tsnode)
+    return
+  end
+
   if mode == JOIN and sr == er then
     notify.info(msg.node_is_already_joined)
     return
   elseif mode == SPLIT and sr ~= er then
     notify.info(msg.node_is_already_splitted)
-    return
-  end
-
-  if type(p.fallback) == 'function' then
-    p.fallback(tsn_data.tsnode)
     return
   end
 

--- a/lua/treesj/format.lua
+++ b/lua/treesj/format.lua
@@ -107,6 +107,12 @@ function M._format(mode, override)
     end
   end
 
+  if mode == JOIN and sr == er then
+    return
+  elseif mode == SPLIT and sr ~= er then
+    return
+  end
+
   if type(p.fallback) == 'function' then
     p.fallback(tsn_data.tsnode)
     return
@@ -149,11 +155,6 @@ function M._format(mode, override)
   local cursor = CHold.new()
   cursor:compute(treesj, MODE)
   local new_cursor = cursor:get_cursor()
-
-  local initial_text = vim.api.nvim_buf_get_text(0, sr, sc, er, ec, {})
-  if vim.deep_equal(initial_text, replacement) then
-    return
-  end
 
   local insert_ok, e =
     pcall(vim.api.nvim_buf_set_text, 0, sr, sc, er, ec, replacement)

--- a/lua/treesj/format.lua
+++ b/lua/treesj/format.lua
@@ -108,8 +108,10 @@ function M._format(mode, override)
   end
 
   if mode == JOIN and sr == er then
+    notify.info(msg.node_is_already_joined)
     return
   elseif mode == SPLIT and sr ~= er then
+    notify.info(msg.node_is_already_splitted)
     return
   end
 

--- a/lua/treesj/notify.lua
+++ b/lua/treesj/notify.lua
@@ -19,6 +19,8 @@ M.msg = {
   custom_func = 'Something went wrong in function "%s" from preset for "%s": %s',
   wrong_resut = 'Function "%s" from preset for "%s" returned wrong format for new lines',
   no_ts_parser = 'Treesitter parser not found for current buffer',
+  node_is_already_joined = 'The current node is already joined',
+  node_is_already_splitted = 'The current node is already splitted',
 }
 
 ---Wraper for vim.notify and nvim-notify


### PR DESCRIPTION
If there was an accidental hitting on the wrong button and the code hasn't changed, the vim considers it a changed buffer (the `modified` option is set). It's a little annoying, so the pr is here.

The solution is to check for changes before setting the text.

I'm not sure:
- should I use `pcall` to call `nvim_buf_get_text`? (I don't why there is `pcall(vim.api.nvim_buf_set_tex...` on the next line
- should I `notify.info` that nothing has changed?