### PR TITLE
Basic elixir support

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ By default, TreeSJ has presets for these languages:
 - **Bash**;
 - **SQL**;
 - **Dart**;
+- **Elixir**;
 
 For adding your favorite language, add it to `langs` sections in your
 configuration. Also, see how [to implement

--- a/doc/treesj.txt
+++ b/doc/treesj.txt
@@ -217,6 +217,7 @@ By default, TreeSJ has presets for these languages:
 - **Bash**;
 - **SQL**;
 - **Dart**;
+- *Elixir*;
 
 For adding your favorite language, add it to `langs` sections in your
 configuration. Also, see how to implement fallback

--- a/lua/treesj/langs/elixir.lua
+++ b/lua/treesj/langs/elixir.lua
@@ -46,7 +46,7 @@ return {
             for keyword in pair:iter_children() do
               if keyword:type() == 'map' then
                 -- Grab the previous node which is the map key
-                local map_key = keyword:prev();
+                local map_key = keyword:prev()
                 -- Add an extra space to account for keyword + map quirkness
                 local text = map_key:text():gsub(':$', ': ')
                 map_key:update_text(text)

--- a/lua/treesj/langs/elixir.lua
+++ b/lua/treesj/langs/elixir.lua
@@ -3,22 +3,30 @@ local lang_utils = require('treesj.langs.utils')
 return {
   list = lang_utils.set_preset_for_list({
     join = {
-      space_in_brackets = false
+      space_in_brackets = false,
     },
     split = {
       recursive = false,
       last_separator = false,
     },
   }),
-  map = {
-    target_nodes = { 'map_content', 'keywords' },
-  },
+  map = { target_nodes = { 'map_content' } },
   map_content = lang_utils.set_preset_for_list({
     both = {
       non_bracket_node = true,
     },
     split = {
       last_separator = false,
+      format_tree = function(tsj)
+        if tsj:has_children({ 'keywords' }) then
+          tsj:update_preset(
+            { recursive = true, recursive_ignore = { 'map' } },
+            'split'
+          )
+          local keywords = tsj:child('keywords')
+          keywords:update_preset({ inner_indent = 'normal' }, 'split')
+        end
+      end,
     },
     join = {
       space_in_brackets = false,
@@ -27,8 +35,21 @@ return {
   keywords = lang_utils.set_preset_for_list({
     both = {
       non_bracket_node = true,
+      format_resulted_lines = function(lines)
+        return vim.tbl_map(function(line)
+          -- Replace ':%{' with ': %{'
+          -- This happens when a keyword is pointing to a map like `foo` here:
+          -- %{ foo: %{ inner: "value" } }
+          if line:match(':%%{') then
+            return line:gsub(':%%{', ': %%{')
+          else
+            return line
+          end
+        end, lines)
+      end,
     },
     split = {
+      inner_indent = 'inner',
       last_separator = false,
     },
     join = {
@@ -38,7 +59,7 @@ return {
   arguments = lang_utils.set_preset_for_args(),
   tuple = lang_utils.set_preset_for_list({
     join = {
-      space_in_brackets = false
+      space_in_brackets = false,
     },
     split = {
       recursive = false,

--- a/lua/treesj/langs/elixir.lua
+++ b/lua/treesj/langs/elixir.lua
@@ -11,9 +11,20 @@ return {
     },
   }),
   map = {
-    target_nodes = { 'map_content' },
+    target_nodes = { 'map_content', 'keywords' },
   },
   map_content = lang_utils.set_preset_for_list({
+    both = {
+      non_bracket_node = true,
+    },
+    split = {
+      last_separator = false,
+    },
+    join = {
+      space_in_brackets = false,
+    },
+  }),
+  keywords = lang_utils.set_preset_for_list({
     both = {
       non_bracket_node = true,
     },

--- a/lua/treesj/langs/elixir.lua
+++ b/lua/treesj/langs/elixir.lua
@@ -1,0 +1,40 @@
+local lang_utils = require('treesj.langs.utils')
+
+return {
+  list = lang_utils.set_preset_for_list({
+    join = {
+      space_in_brackets = false
+    },
+    split = {
+      recursive = false,
+      last_separator = false,
+    },
+  }),
+  map = {
+    target_nodes = { 'map_content' },
+  },
+  map_content = lang_utils.set_preset_for_list({
+    both = {
+      non_bracket_node = true,
+    },
+    split = {
+      last_separator = false,
+    },
+    join = {
+      space_in_brackets = false,
+    },
+  }),
+  arguments = lang_utils.set_preset_for_args(),
+  tuple = lang_utils.set_preset_for_list({
+    join = {
+      space_in_brackets = false
+    },
+    split = {
+      recursive = false,
+      last_separator = false,
+    },
+  }),
+  binary_operator = {
+    target_nodes = { 'list', 'map', 'tuple' },
+  },
+}

--- a/lua/treesj/langs/init.lua
+++ b/lua/treesj/langs/init.lua
@@ -33,6 +33,7 @@ M.configured_langs = {
   'bash',
   'sql',
   'dart',
+  'elixir'
 }
 
 M.presets = {}

--- a/tests/langs/elixir/join_spec.lua
+++ b/tests/langs/elixir/join_spec.lua
@@ -67,6 +67,24 @@ local data_for_join = {
     expected = { 61, 62 },
     result = { 64, 65 },
   },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "list" with "keywords" and "map", preset default',
+    cursor = { 76, 4 },
+    expected = { 71, 72 },
+    result = { 74, 75 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "map" nested "keywords" and "maps", preset default',
+    cursor = { 87, 10 },
+    expected = { 82, 83 },
+    result = { 85, 86 },
+  },
 }
 
 local treesj = require('treesj')

--- a/tests/langs/elixir/join_spec.lua
+++ b/tests/langs/elixir/join_spec.lua
@@ -49,6 +49,24 @@ local data_for_join = {
     expected = { 41, 42 },
     result = { 44, 45 },
   },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "keywords", preset default',
+    cursor = { 57, 6 },
+    expected = { 52, 53 },
+    result = { 55, 56 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "map" with "keywords" and "map_content", preset default',
+    cursor = { 65, 8 },
+    expected = { 61, 62 },
+    result = { 64, 65 },
+  },
 }
 
 local treesj = require('treesj')

--- a/tests/langs/elixir/join_spec.lua
+++ b/tests/langs/elixir/join_spec.lua
@@ -1,0 +1,62 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.ex'
+local LANG = 'elixir'
+
+local data_for_join = {
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "list", preset default',
+    cursor = { 8, 4 },
+    expected = { 1, 2 },
+    result = { 4, 5 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "map", preset default',
+    cursor = { 18, 15 },
+    expected = { 13, 14 },
+    result = { 16, 17 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "arguments", preset default',
+    cursor = { 28, 3 },
+    expected = { 23, 24 },
+    result = { 26, 27 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "arguments", preset default',
+    cursor = { 37, 3 },
+    expected = { 32, 33 },
+    result = { 35, 36 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "tuple", preset default',
+    cursor = { 46, 2 },
+    expected = { 41, 42 },
+    result = { 44, 45 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ JOIN:', function()
+  for _, value in ipairs(data_for_join) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/langs/elixir/split_spec.lua
+++ b/tests/langs/elixir/split_spec.lua
@@ -67,6 +67,24 @@ local data_for_split = {
     expected = { 64, 69 },
     result = { 61, 66 },
   },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "list" with "keywords" and "map", preset default',
+    cursor = { 72, 9 },
+    expected = { 74, 80 },
+    result = { 71, 77 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "map" nested "keywords" and "maps", preset default',
+    cursor = { 83, 15 },
+    expected = { 85, 91 },
+    result = { 82, 88 },
+  },
 }
 
 local treesj = require('treesj')

--- a/tests/langs/elixir/split_spec.lua
+++ b/tests/langs/elixir/split_spec.lua
@@ -49,6 +49,24 @@ local data_for_split = {
     expected = { 44, 50 },
     result = { 41, 47 },
   },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "keywords", preset default',
+    cursor = { 53, 9 },
+    expected = { 55, 59 },
+    result = { 52, 56 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "map" with "keywords" and "map_content", preset default',
+    cursor = { 62, 8 },
+    expected = { 64, 69 },
+    result = { 61, 66 },
+  },
 }
 
 local treesj = require('treesj')

--- a/tests/langs/elixir/split_spec.lua
+++ b/tests/langs/elixir/split_spec.lua
@@ -1,0 +1,62 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.ex'
+local LANG = 'elixir'
+
+local data_for_split = {
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "list", preset default',
+    cursor = { 2, 13 },
+    expected = { 4, 11 },
+    result = { 1, 8 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "map", preset default',
+    cursor = { 14, 17 },
+    expected = { 16, 21 },
+    result = { 13, 18 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "arguments", preset default',
+    cursor = { 24, 11 },
+    expected = { 26, 30 },
+    result = { 23, 27 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "arguments", preset default',
+    cursor = { 33, 7 },
+    expected = { 35, 39 },
+    result = { 32, 36 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "tuple", preset default',
+    cursor = { 42, 5 },
+    expected = { 44, 50 },
+    result = { 41, 47 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ SPLIT:', function()
+  for _, value in ipairs(data_for_split) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/sample/index.ex
+++ b/tests/sample/index.ex
@@ -10,10 +10,10 @@ list = [
   [3, 4]
 ]
 
-# RESULT OF JOIN (node "map", preset default)
+# RESULT OF JOIN (node "map_content", preset default)
 map = %{:foo => "foo", :bar => "bar", [1, 2] => 2}
 
-# RESULT OF SPLIT (node "map", preset default)
+# RESULT OF SPLIT (node "map_content", preset default)
 map = %{
   :foo => "foo",
   :bar => "bar",
@@ -47,4 +47,23 @@ test(
   b,
   123,
   {c, d}
+}
+
+# RESULT OF JOIN (node "keywords", preset default)
+map = %{foo: "bar", baz: "bar"}
+
+# RESULT OF SPLIT (node "keywords", preset default)
+map = %{
+  foo: "bar",
+  baz: "bar"
+}
+
+# RESULT OF JOIN (node "map" with "keywords" and "map_content", preset default)
+map = %{"key" => "value", foo: "bar", baz: "bar"}
+
+# RESULT OF SPLIT (node "map" with "keywords" and "map_content", preset default)
+map = %{
+  "key" => "value",
+  foo: "bar",
+  baz: "bar"
 }

--- a/tests/sample/index.ex
+++ b/tests/sample/index.ex
@@ -67,3 +67,25 @@ map = %{
   foo: "bar",
   baz: "bar"
 }
+
+# RESULT OF JOIN (node "list" with "keywords" and "map", preset default)
+list = [1, 2, %{"a" => "b", key: "value", foo: "bar"}, abc: "123", def: "456"]
+
+# RESULT OF SPLIT (node "list" with "keywords" and "map", preset default)
+list = [
+  1,
+  2,
+  %{"a" => "b", key: "value", foo: "bar"},
+  abc: "123", def: "456"
+]
+
+# RESULT OF JOIN (node "map" nested "keywords" and "maps"", preset default)
+map = %{"map" => %{"key" => "value"}, foo: "bar", map: %{"key" => "value"}, baz: "bar"}
+
+# RESULT OF SPLIT (node "map" nested "keywords" and "maps", preset default)
+map = %{
+  "map" => %{"key" => "value"},
+  foo: "bar",
+  map: %{"key" => "value"},
+  baz: "bar"
+}

--- a/tests/sample/index.ex
+++ b/tests/sample/index.ex
@@ -1,0 +1,50 @@
+# RESULT OF JOIN (node "list", preset default)
+list = [1, 2, 3, [1, 2], [3, 4]]
+
+# RESULT OF SPLIT (node "list", preset default)
+list = [
+  1,
+  2,
+  3,
+  [1, 2],
+  [3, 4]
+]
+
+# RESULT OF JOIN (node "map", preset default)
+map = %{:foo => "foo", :bar => "bar", [1, 2] => 2}
+
+# RESULT OF SPLIT (node "map", preset default)
+map = %{
+  :foo => "foo",
+  :bar => "bar",
+  [1, 2] => 2
+}
+
+# RESULT OF JOIN (node "arguments", preset default)
+def test(a, b), do: :ok
+
+# RESULT OF SPLIT (node "arguments", preset default)
+def test(
+  a,
+  b
+), do: :ok
+
+# RESULT OF JOIN (node "arguments", preset default)
+test(a, b)
+
+# RESULT OF SPLIT (node "arguments", preset default)
+test(
+  a,
+  b
+)
+
+# RESULT OF JOIN (node "tuple", preset default)
+{a, b, 123, {c, d}}
+
+# RESULT OF SPLIT (node "tuple", preset default)
+{
+  a,
+  b,
+  123,
+  {c, d}
+}


### PR DESCRIPTION
Thanks for the great project! 

This PR adds basic support to Elixir. I've implemented just the most basic setup to get started but hopefully we can improve it later.

* lists
* tuples
* arguments

I've tried my best to include support for maps but I couldn't find a way to make this work :disappointed: 

I think the main issue is that `map` holds a `map_content` which then holds the children key-values.  

```
    right: (map ; [16, 6] - [20, 1]
      (map_content ; [17, 2] - [19, 13]
        (binary_operator ; [17, 2] - [17, 15]
          left: (atom) ; [17, 2] - [17, 6]
          right: (string ; [17, 10] - [17, 15]
            (quoted_content))) ; [17, 11] - [17, 14]
        (binary_operator ; [18, 2] - [18, 15]
          left: (atom) ; [18, 2] - [18, 6]
          right: (string ; [18, 10] - [18, 15]
            (quoted_content))) ; [18, 11] - [18, 14]
        (binary_operator ; [19, 2] - [19, 13]
          left: (list ; [19, 2] - [19, 8]
            (integer) ; [19, 3] - [19, 4]
            (integer)) ; [19, 6] - [19, 7]
          right: (integer))))) ; [19, 12] - [19, 13]
```