### PR TITLE
Add Terraform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ By default, TreeSJ has presets for these languages:
 - **Haskell**;
 - **Zig**;
 - **Julia**;
+- **Terraform**;
 
 For adding your favorite language, add it to `langs` sections in your
 configuration. Also, see how [to implement

--- a/lua/treesj/langs/init.lua
+++ b/lua/treesj/langs/init.lua
@@ -37,6 +37,7 @@ M.configured_langs = {
   'haskell',
   'zig',
   'julia',
+  'terraform',
 }
 
 M.presets = {}

--- a/lua/treesj/langs/terraform.lua
+++ b/lua/treesj/langs/terraform.lua
@@ -1,0 +1,36 @@
+local lang_utils = require('treesj.langs.utils')
+
+return {
+  tuple = lang_utils.set_preset_for_list({
+    join = {
+      space_in_brackets = false,
+    },
+  }),
+  object = lang_utils.set_preset_for_dict({
+    split = {
+      separator = '',
+      format_tree = function(tsj)
+        tsj:remove_child(',')
+      end,
+    },
+    join = {
+      space_in_brackets = false,
+      force_insert = ',',
+      no_insert_if = { lang_utils.helpers.if_penultimate },
+    },
+  }),
+  function_call = {
+    target_nodes = { 'function_arguments' },
+  },
+  function_arguments = lang_utils.set_preset_for_args({
+    both = {
+      non_bracket_node = true,
+    },
+    join = {
+      recursive = true,
+    },
+    split = {
+      last_separator = true,
+    },
+  }),
+}

--- a/tests/langs/terraform/join_spec.lua
+++ b/tests/langs/terraform/join_spec.lua
@@ -1,0 +1,54 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.tf'
+local LANG = 'terraform'
+local MODE = 'join'
+
+local data = {
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "tuple", preset default',
+    cursor = { 3, 14 },
+    result = { 3, 8 },
+    expected = { 6, 11 },
+  },
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "object", preset default',
+    cursor = { 18, 10 },
+    result = { 16, 17 },
+    expected = { 13, 14 },
+  },
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "function_call", preset default',
+    cursor = { 26, 11 },
+    result = { 26, 27 },
+    expected = { 23, 24 },
+  },
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "function_arguments", preset default',
+    cursor = { 27, 8 },
+    result = { 26, 27 },
+    expected = { 23, 24 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ ' .. MODE:upper() .. ':', function()
+  for _, value in ipairs(data) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/langs/terraform/join_spec.lua
+++ b/tests/langs/terraform/join_spec.lua
@@ -10,9 +10,9 @@ local data = {
     mode = MODE,
     lang = LANG,
     desc = 'lang "%s", node "tuple", preset default',
-    cursor = { 3, 14 },
-    result = { 3, 8 },
-    expected = { 6, 11 },
+    result = { 5, 6 },
+    cursor = { 7, 5 },
+    expected = { 2, 3 },
   },
   {
     path = PATH,
@@ -20,8 +20,8 @@ local data = {
     lang = LANG,
     desc = 'lang "%s", node "object", preset default',
     cursor = { 18, 10 },
-    result = { 16, 17 },
-    expected = { 13, 14 },
+    result = { 15, 16 },
+    expected = { 12, 13 },
   },
   {
     path = PATH,
@@ -29,8 +29,8 @@ local data = {
     lang = LANG,
     desc = 'lang "%s", node "function_call", preset default',
     cursor = { 26, 11 },
-    result = { 26, 27 },
-    expected = { 23, 24 },
+    result = { 25, 26 },
+    expected = { 22, 23 },
   },
   {
     path = PATH,
@@ -38,8 +38,8 @@ local data = {
     lang = LANG,
     desc = 'lang "%s", node "function_arguments", preset default',
     cursor = { 27, 8 },
-    result = { 26, 27 },
-    expected = { 23, 24 },
+    result = { 25, 26 },
+    expected = { 22, 23 },
   },
 }
 

--- a/tests/langs/terraform/split_spec.lua
+++ b/tests/langs/terraform/split_spec.lua
@@ -10,9 +10,9 @@ local data = {
     mode = MODE,
     lang = LANG,
     desc = 'lang "%s", node "tuple", preset default',
-    cursor = { 7, 6 },
-    result = { 6, 7 },
-    expected = { 3, 4 },
+    cursor = { 3, 12},
+    result = { 2, 7 },
+    expected = { 5, 10},
   },
   {
     path = PATH,
@@ -20,8 +20,8 @@ local data = {
     lang = LANG,
     desc = 'lang "%s", node "object", preset default',
     cursor = { 13, 33 },
-    result = { 13, 18 },
-    expected = { 16, 21 },
+    result = { 12, 17 },
+    expected = { 15, 20 },
   },
   {
     path = PATH,
@@ -29,8 +29,8 @@ local data = {
     lang = LANG,
     desc = 'lang "%s", node "function_call", preset default',
     cursor = { 23, 11 },
-    result = { 23, 28 },
-    expected = { 26, 31 },
+    result = { 22, 27 },
+    expected = { 25, 30 },
   },
   {
     path = PATH,
@@ -38,8 +38,8 @@ local data = {
     lang = LANG,
     desc = 'lang "%s", node "function_arguments", preset default',
     cursor = { 23, 18 },
-    result = { 23, 28 },
-    expected = { 26, 31 },
+    result = { 22, 27 },
+    expected = { 25, 30 },
   },
 }
 

--- a/tests/langs/terraform/split_spec.lua
+++ b/tests/langs/terraform/split_spec.lua
@@ -1,0 +1,54 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.tf'
+local LANG = 'terraform'
+local MODE = 'split'
+
+local data = {
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "tuple", preset default',
+    cursor = { 7, 6 },
+    result = { 6, 7 },
+    expected = { 3, 4 },
+  },
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "object", preset default',
+    cursor = { 13, 33 },
+    result = { 13, 18 },
+    expected = { 16, 21 },
+  },
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "function_call", preset default',
+    cursor = { 23, 11 },
+    result = { 23, 28 },
+    expected = { 26, 31 },
+  },
+  {
+    path = PATH,
+    mode = MODE,
+    lang = LANG,
+    desc = 'lang "%s", node "function_arguments", preset default',
+    cursor = { 23, 18 },
+    result = { 23, 28 },
+    expected = { 26, 31 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ ' .. MODE:upper() .. ':', function()
+  for _, value in ipairs(data) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/sample/index.tf
+++ b/tests/sample/index.tf
@@ -3,7 +3,7 @@ locals {
   tuple1 = ["hello", ["nested"], "world"]
 
   # RESULT OF SPLIT (node "tuple", preset default)
-  tuple2 = [
+  tuple1 = [
     "hello",
     ["nested"],
     "world",
@@ -13,7 +13,7 @@ locals {
   object1 = {field = true, other_field = 42, yet_another_one = "thank you"}
 
   # RESULT OF SPLIT (node "object", preset default)
-  object2 = {
+  object1 = {
     field = true
     other_field = 42
     yet_another_one = "thank you"
@@ -23,7 +23,7 @@ locals {
   fn1 = hello(null, {foo = "bar!"}, 0.5)
 
   # RESULT OF SPLIT (node "function_call", preset default)
-  fn2 = hello(
+  fn1 = hello(
     null,
     {foo = "bar!"},
     0.5,

--- a/tests/sample/index.tf
+++ b/tests/sample/index.tf
@@ -1,0 +1,31 @@
+locals {
+  # RESULT OF JOIN (node "tuple", preset default)
+  tuple1 = ["hello", ["nested"], "world"]
+
+  # RESULT OF SPLIT (node "tuple", preset default)
+  tuple2 = [
+    "hello",
+    ["nested"],
+    "world",
+  ]
+
+  # RESULT OF JOIN (node "object", preset default)
+  object1 = {field = true, other_field = 42, yet_another_one = "thank you"}
+
+  # RESULT OF SPLIT (node "object", preset default)
+  object2 = {
+    field = true
+    other_field = 42
+    yet_another_one = "thank you"
+  }
+
+  # RESULT OF JOIN (node "function_call", preset default)
+  fn1 = hello(null, {foo = "bar!"}, 0.5)
+
+  # RESULT OF SPLIT (node "function_call", preset default)
+  fn2 = hello(
+    null,
+    {foo = "bar!"},
+    0.5,
+  )
+}


### PR DESCRIPTION
Closes #176 

I tried to add tests but have hit a few roadblocks:
1. When I try to run the tests (for all langs or just for terraform) the test runner seems to hang after outputing a few `Scheduling: path/to/..._spec.lua` lines (I tried on MacOS for now)
2. I don't understand the `result` data field 🤔
   (also, shouldn't `expected` be `{ 3, 7 }` for `data_for_split` in the example?)