### PR TITLE
feat: add zsh preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ By default, TreeSJ has presets for these languages:
 - **Nix**;
 - **Kotlin**;
 - **Bash**;
+- **Zsh**;
 - **SQL**;
 - **Dart**;
 - **Elixir**;

--- a/lua/treesj/langs/init.lua
+++ b/lua/treesj/langs/init.lua
@@ -31,6 +31,7 @@ M.configured_langs = {
   'nix',
   'kotlin',
   'bash',
+  'zsh',
   'sql',
   'dart',
   'elixir',

--- a/lua/treesj/langs/zsh.lua
+++ b/lua/treesj/langs/zsh.lua
@@ -1,0 +1,4 @@
+local lang_utils = require('treesj.langs.utils')
+local bash = require('treesj.langs.bash')
+
+return lang_utils.merge_preset(bash, {})


### PR DESCRIPTION
Recently, treesitter added the zsh parser: https://github.com/nvim-treesitter/nvim-treesitter/pull/8240

Thus, I added split-join-support for zsh as well.

Since bash and zsh are so similar though, the nodes and rules for joining/splitting are basically the same, so I zsh can for now just inherit the bash preset.