### PR TITLE
feat: adding qml preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ By default, TreeSJ has presets for these languages:
 - **Julia**;
 - **Terraform**;
 - **Typst**;
+- **Qml**;
 
 For adding your favorite language, add it to `langs` sections in your
 configuration. Also, see how [to implement

--- a/lua/treesj/langs/init.lua
+++ b/lua/treesj/langs/init.lua
@@ -40,6 +40,8 @@ M.configured_langs = {
   'julia',
   'terraform',
   'typst',
+  'qml',
+  'qmljs',
 }
 
 M.presets = {}

--- a/lua/treesj/langs/qml.lua
+++ b/lua/treesj/langs/qml.lua
@@ -1,0 +1,88 @@
+local lang_utils = require('treesj.langs.utils')
+
+local statement_preset = {
+  join = {
+    force_insert = ';',
+    space_in_brackets = true,
+    space_separator = true,
+  },
+}
+
+local function get_block_preset(extra_no_insert, penultimate)
+  local no_insert = extra_no_insert or {}
+
+  if penultimate then
+    table.insert(no_insert, lang_utils.helpers.if_penultimate)
+  end
+
+  return lang_utils.set_preset_for_dict({
+
+    join = {
+      force_insert = ';',
+      space_in_brackets = true,
+      space_separator = true,
+      no_insert_if = no_insert,
+      format_resulted_lines = function(lines)
+        if penultimate then
+          local target_index = #lines - 1
+
+          if target_index > 1 and lines[target_index] then
+            lines[target_index] = lines[target_index]:gsub(';%s*$', '')
+          end
+
+          return lines
+        end
+
+        return lines
+      end,
+    },
+
+    split = {
+      separator = '',
+      force_insert = '',
+      space_in_brackets = true,
+      space_separator = true,
+      recursive = true,
+      format_resulted_lines = function(lines)
+        for i, line in ipairs(lines) do
+          lines[i] = line:gsub(';%s*$', '')
+        end
+        return lines
+      end,
+    },
+  })
+end
+
+return {
+  array = lang_utils.set_preset_for_list(),
+  ui_object_array = lang_utils.set_preset_for_list(),
+
+  object = lang_utils.set_preset_for_dict(),
+  ui_object_definition = lang_utils.set_preset_for_dict(),
+  ui_object_initializer = get_block_preset({
+    'ui_object_definition',
+    'ui_object_definition_binding',
+    'ui_inline_component',
+    'function_declaration',
+  }, true),
+
+  function_declaration = {
+    target_nodes = { 'formal_parameters', 'statement_block' },
+  },
+  formal_parameters = lang_utils.set_preset_for_list(),
+
+  statement_block = get_block_preset({}, false),
+
+  if_statement = {
+    target_nodes = { 'statement_block' },
+  },
+
+  else_clause = {
+    target_nodes = { 'statement_block' },
+  },
+
+  lexical_declaration = statement_preset,
+  variable_declaration = statement_preset,
+  break_statement = statement_preset,
+  continue_statement = statement_preset,
+}

--- a/lua/treesj/langs/qmljs.lua
+++ b/lua/treesj/langs/qmljs.lua
@@ -1,0 +1,4 @@
+local lang_utils = require('treesj.langs.utils')
+local qml = require('treesj.langs.qml')
+
+return lang_utils.merge_preset(qml, {})

--- a/tests/langs/qml/join_spec.lua
+++ b/tests/langs/qml/join_spec.lua
@@ -1,0 +1,62 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.qml'
+local LANG = 'qml'
+
+local data_for_join = {
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "ui_object_initializer", custom preset',
+    cursor = { 10, 10 },
+    expected = { 7, 7 },
+    result = { 7, 7 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "array", preset default',
+    cursor = { 20, 25 },
+    result = { 17, 17 },
+    expected = { 17, 17 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "function_declaration", preset default',
+    cursor = { 31, 8 },
+    expected = { 27, 27 },
+    result = { 27, 27 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "statement_block", custom preset',
+    cursor = { 39, 7 },
+    expected = { 35, 35 },
+    result = { 35, 35 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "statement_block" , more complicated, custom preset',
+    cursor = { 51, 14 },
+    expected = { 48, 48 },
+    result = { 48, 48 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ JOIN:', function()
+  for _, value in ipairs(data_for_join) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/langs/qml/split_spec.lua
+++ b/tests/langs/qml/split_spec.lua
@@ -1,0 +1,62 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.qml'
+local LANG = 'qml'
+
+local data_for_split = {
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "ui_object_initializer", custom preset',
+    cursor = { 7, 9 },
+    expected = { 10, 14 },
+    result = { 10, 14 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "array", preset default',
+    cursor = { 17, 25 },
+    expected = { 20, 24 },
+    result = { 20, 24 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "function_declaration", preset default',
+    cursor = { 27, 41 },
+    expected = { 30, 32 },
+    result = { 30, 32 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "statement_block", custom preset',
+    cursor = { 35, 36 },
+    expected = { 38, 44 },
+    result = { 38, 44 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "statement_block" , more complicated, custom preset',
+    cursor = { 47, 14 },
+    expected = { 47, 64 },
+    result = { 47, 64 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ SPLIT:', function()
+  for _, value in ipairs(data_for_split) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/sample/index.qml
+++ b/tests/sample/index.qml
@@ -1,0 +1,65 @@
+import QtQuick
+
+Item {
+    id: root
+
+    // RESULT OF JOIN (node "ui_object_initializer")
+    Item { id: container; width: 200; height: 200 }
+
+    // RESULT OF SPLIT (node "ui_object_initializer")
+    Item {
+        id: container
+        width: 200
+        height: 200
+    }
+
+    // RESULT OF JOIN (node "array")
+    property var colors: [ "red", "green", "blue" ]
+
+    // RESULT OF SPLIT (node "array")
+    property var colors: [
+    "red",
+    "green",
+    "blue",
+    ]
+
+    // RESULT OF JOIN (node "function_declaration")
+    function calc( x: int, y: int ): int { return x + y; }
+
+    // RESULT OF SPLIT (node "function_declaration")
+    function calc( x: int, y: int ): int {
+        return x + y
+    }
+
+    // RESULT OF JOIN (node "statement_block")
+    function checkStatus (x:string) { if (x == "ok") { return true; } else { return false; }; }
+
+    // RESULT OF SPLIT (node "statement_block")
+    function checkStatus (x:string) {
+        if (x == "ok") {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    // RESULT OF JOIN (node "statement_block") more complicated
+    MouseArea { id: mouseArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; onClicked: { rect.isExpanded = !rect.isExpanded; if (rect.isExpanded) { rect.x = root.width - rect.width; } else { rect.x = 0; rect.y = 0; }; rect.y = root.height - rect.height; } }
+
+    // RESULT OF SPLIT (node "statement_block") more complicated
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        cursorShape: Qt.PointingHandCursor
+        onClicked: {
+            rect.isExpanded = !rect.isExpanded
+            if (rect.isExpanded) {
+                rect.x = root.width - rect.width
+            } else {
+                rect.x = 0
+                rect.y = 0
+            }
+            rect.y = root.height - rect.height
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR adds support for the **QML** language (`qml`) to TreeSJ.

### Supported Nodes & Features
- `ui_object_initializer` (e.g., QML objects/elements like `Item { ... }`)
- `array` (e.g., property arrays)
- `function_declaration` and `statement_block` (both simple and if/else functions)

### Changes
- Added language configuration and default presets for QML.
- Created `split_spec.lua` and `join_spec.lua` tests under `tests/langs/qml/`.
- Updated `README.md` to list QML under supported languages.

All tests run and pass cleanly via `make test-langs LP=qml`.