### PR TITLE
feat: add gdscript preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ By default, TreeSJ has presets for these languages:
 - **Terraform**;
 - **Typst**;
 - **Qml**;
+- **GDScript**;
 
 For adding your favorite language, add it to `langs` sections in your
 configuration. Also, see how [to implement

--- a/lua/treesj/langs/gdscript.lua
+++ b/lua/treesj/langs/gdscript.lua
@@ -1,0 +1,48 @@
+local lang_utils = require('treesj.langs.utils')
+
+local no_space_in_brackets_list = lang_utils.set_preset_for_list({
+  join = { space_in_brackets = false },
+})
+local no_space_in_brackets_dict = lang_utils.set_preset_for_dict({
+  join = { space_in_brackets = false },
+})
+
+return {
+  arguments = lang_utils.set_preset_for_args(),
+  parameters = lang_utils.set_preset_for_args(),
+  array = no_space_in_brackets_list,
+  dictionary = no_space_in_brackets_dict,
+  enumerator_list = no_space_in_brackets_dict,
+
+  call = {
+    target_nodes = { 'arguments' },
+  },
+  attribute_call = {
+    target_nodes = { 'arguments' },
+  },
+  lambda = {
+    target_nodes = { 'parameters' },
+  },
+  function_definition = {
+    target_nodes = { 'parameters' },
+  },
+  enum_definition = {
+    target_nodes = { 'enumerator_list' },
+  },
+
+  assignment = {
+    target_nodes = { 'array', 'dictionary', 'arguments' },
+  },
+  augmented_assignment = {
+    target_nodes = { 'array', 'dictionary', 'arguments' },
+  },
+  variable_statement = {
+    target_nodes = { 'array', 'dictionary', 'arguments' },
+  },
+  const_statement = {
+    target_nodes = { 'array', 'dictionary', 'arguments' },
+  },
+  return_statement = {
+    target_nodes = { 'array', 'dictionary', 'arguments' },
+  },
+}

--- a/lua/treesj/langs/init.lua
+++ b/lua/treesj/langs/init.lua
@@ -42,6 +42,7 @@ M.configured_langs = {
   'typst',
   'qml',
   'qmljs',
+  'gdscript',
 }
 
 M.presets = {}

--- a/tests/langs/gdscript/gdscript_join_spec.lua
+++ b/tests/langs/gdscript/gdscript_join_spec.lua
@@ -1,0 +1,71 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.gd'
+local LANG = 'gdscript'
+
+local data_for_join = {
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "array", preset default',
+    cursor = { 5, 2 },
+    expected = { 1, 2 },
+    result = { 3, 4 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "dictionary", preset default',
+    cursor = { 14, 2 },
+    expected = { 10, 11 },
+    result = { 12, 13 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "enumerator_list" and "enum_definition", preset default',
+    cursor = { 22, 2 },
+    expected = { 18, 19 },
+    result = { 20, 21 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "parameters" and "function_definition", preset default',
+    cursor = { 33, 2 },
+    expected = { 27, 29 },
+    result = { 31, 33 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "arguments" and "call", preset default',
+    cursor = { 45, 4 },
+    expected = { 39, 40 },
+    result = { 43, 44 },
+  },
+  {
+    path = PATH,
+    mode = 'join',
+    lang = LANG,
+    desc = 'lang "%s", node "assignment" (array), preset default',
+    cursor = { 57, 4 },
+    expected = { 51, 52 },
+    result = { 55, 56 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ JOIN:', function()
+  for _, value in ipairs(data_for_join) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/langs/gdscript/gdscript_split_spec.lua
+++ b/tests/langs/gdscript/gdscript_split_spec.lua
@@ -1,0 +1,71 @@
+local tu = require('tests.utils')
+
+local PATH = './tests/sample/index.gd'
+local LANG = 'gdscript'
+
+local data_for_split = {
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "array", preset default',
+    cursor = { 2, 11 },
+    expected = { 3, 8 },
+    result = { 1, 6 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "dictionary", preset default',
+    cursor = { 11, 11 },
+    expected = { 12, 16 },
+    result = { 10, 14 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "enumerator_list" and "enum_definition", preset default',
+    cursor = { 19, 11 },
+    expected = { 20, 25 },
+    result = { 18, 23 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "parameters" and "function_definition", preset default',
+    cursor = { 28, 11 },
+    expected = { 31, 36 },
+    result = { 27, 32 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "arguments" and "call", preset default',
+    cursor = { 40, 15 },
+    expected = { 43, 48 },
+    result = { 39, 44 },
+  },
+  {
+    path = PATH,
+    mode = 'split',
+    lang = LANG,
+    desc = 'lang "%s", node "assignment" (array), preset default',
+    cursor = { 52, 2 },
+    expected = { 55, 60 },
+    result = { 51, 56 },
+  },
+}
+
+local treesj = require('treesj')
+local opts = {}
+treesj.setup(opts)
+
+describe('TreeSJ SPLIT:', function()
+  for _, value in ipairs(data_for_split) do
+    tu._test_format(value, treesj)
+  end
+end)

--- a/tests/sample/index.gd
+++ b/tests/sample/index.gd
@@ -1,0 +1,60 @@
+# RESULT OF JOIN (node "array", preset default)
+var arr = [1, 2, 3]
+# RESULT OF SPLIT (node "array", preset default)
+var arr = [
+  1,
+  2,
+  3,
+]
+
+# RESULT OF JOIN (node "dictionary", preset default)
+var dct = {"one": 1, "two": 2}
+# RESULT OF SPLIT (node "dictionary", preset default)
+var dct = {
+  "one": 1,
+  "two": 2,
+}
+
+# RESULT OF JOIN (node "enumerator_list" and "enum_definition", preset default)
+enum Mode {IDLE, RUN, JUMP}
+# RESULT OF SPLIT (node "enumerator_list" and "enum_definition", preset default)
+enum Mode {
+  IDLE,
+  RUN,
+  JUMP,
+}
+
+# RESULT OF JOIN (node "parameters" and "function_definition", preset default)
+func greet(name, times):
+  print(name, times)
+
+# RESULT OF SPLIT (node "parameters" and "function_definition", preset default)
+func greet(
+  name,
+  times
+):
+  print(name, times)
+
+# RESULT OF JOIN (node "arguments" and "call", preset default)
+func use():
+  emit_signal("done", a, b)
+
+# RESULT OF SPLIT (node "arguments" and "call", preset default)
+func use():
+  emit_signal(
+    "done",
+    a,
+    b
+  )
+
+# RESULT OF JOIN (node "assignment" (array), preset default)
+func reassign():
+  values = [1, 2, 3]
+
+# RESULT OF SPLIT (node "assignment" (array), preset default)
+func reassign():
+  values = [
+    1,
+    2,
+    3,
+  ]


### PR DESCRIPTION
⚠️ disclaimer: FYI: code for this PR is entirely written by AI 🤖. 

---

# Add a split/join preset for GDScript (from the Godot Game Engine)(tree-sitter-gdscript):

## Bracketed nodes

- `arguments`, `parameters` — argument/parameter lists
- `array`, `dictionary`, `enumerator_list`
Arrays, dictionaries and enum bodies join without inner spaces (`[1, 2]`, `{"a": 1}`, `{IDLE, RUN}`), matching the GDScript style guide.

## Redirects

- `call` / `attribute_call` → `arguments`
- `function_definition` / `lambda` → `parameters`
- `enum_definition` → `enumerator_list`
- `assignment` / `augmented_assignment` / `variable_statement` / `const_statement` / `return_statement` → `array` / `dictionary` / `arguments`

## Tests / docs

- `tests/sample/index.gd` + `tests/langs/gdscript/{split,join}_spec.lua`
- registered `gdscript` in `configured_langs`
- added to the README language list

---

Out of scope (for now): statement bodies (`if`/`for`/`while`/`match`/function bodies). GDScript blocks are indentation-delimited with no closing token, which the current `non_bracket` range model can't frame; I have a follow-up that adds an opt-in core flag to support it.