### PR TITLE
non-bracket outer framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ local node_type = {
     omit = {},
     ---Non-bracket nodes (e.g., with 'then|()' ... 'end' instead of { ... }|< ... >|[ ... ])
     ---If value is table, should be contains follow keys: { left = 'text', right = 'text' }. Empty string uses by default
+    ---For indentation-based blocks with no closing delimiter, add `outer_framing = false` to stop framing from extending to the parent's sibling
     ---@type boolean|table
     non_bracket_node = false,
     ---If you need to process only nodes in the range from / to.
@@ -637,6 +638,13 @@ node imitators are created with an empty value) or take a table that
 specifies what text should wrap the actual base node.
 
 E.g., table value: `{ left = 'text', right = 'text' }`
+
+For indentation-based blocks that have no closing delimiter (e.g. Python,
+GDScript), also set `outer_framing = false`, e.g.
+`{ left = '', right = '', outer_framing = false }`. By default the range
+framing climbs to the parent's sibling when the node has none of its own; for
+such blocks that sibling is the following statement, so the join range would
+otherwise extend over it and swallow it.
 
 <details>
 

--- a/lua/treesj/langs/default_preset.lua
+++ b/lua/treesj/langs/default_preset.lua
@@ -40,6 +40,7 @@ return {
     omit = {},
     ---Non-bracket nodes (e.g., with 'then|()' ... 'end' instead of { ... }|< ... >|[ ... ])
     ---If value is table, should be contains follow keys: { left = 'text', right = 'text' }. Empty string uses by default
+    ---For indentation-based blocks with no closing delimiter, add `outer_framing = false` to stop framing from extending to the parent's sibling
     ---@type boolean|table
     non_bracket_node = false,
     ---If you need to process only nodes in the range from / to.

--- a/lua/treesj/search.lua
+++ b/lua/treesj/search.lua
@@ -289,9 +289,20 @@ function M.range(tsn, preset)
   local er, ec = get_last_symbol_range(tsn, to)
 
   if preset and (non_bracket_node and not shrink_node) then
+    -- Indentation-based blocks (e.g. GDScript) have no closing delimiter token.
+    -- Setting `non_bracket_node.outer_framing = false` stops framing from
+    -- climbing to the parent's sibling, which would otherwise extend the range
+    -- over the following statement and swallow it.
+    local climb = type(non_bracket_node) ~= 'table'
+      or non_bracket_node.outer_framing ~= false
+
     local function get_framing_for_non_bracket(n)
-      local first = n:prev_sibling() or n:parent():prev_sibling()
-      local last = n:next_sibling() or n:parent():next_sibling()
+      local first = n:prev_sibling()
+      local last = n:next_sibling()
+      if climb then
+        first = first or n:parent():prev_sibling()
+        last = last or n:parent():next_sibling()
+      end
       return first, last
     end
 

--- a/lua/treesj/search.lua
+++ b/lua/treesj/search.lua
@@ -289,10 +289,8 @@ function M.range(tsn, preset)
   local er, ec = get_last_symbol_range(tsn, to)
 
   if preset and (non_bracket_node and not shrink_node) then
-    -- Indentation-based blocks (e.g. GDScript) have no closing delimiter token.
-    -- Setting `non_bracket_node.outer_framing = false` stops framing from
-    -- climbing to the parent's sibling, which would otherwise extend the range
-    -- over the following statement and swallow it.
+    -- Indentation-based blocks (e.g. Python) have no closing delimiter token.
+    -- `outer_framing = false` stops framing from climbing to the parent's sibling
     local climb = type(non_bracket_node) ~= 'table'
       or non_bracket_node.outer_framing ~= false
 


### PR DESCRIPTION
⚠️ disclaimer: FYI: code for this PR is entirely written by AI 🤖.

---

# support non_bracket nodes without a closing delimiter

## What

Adds an opt-in `non_bracket_node.outer_framing` option (default `true`). Setting it to `false` stops a `non_bracket` node's format range from climbing to its **parent's** sibling when the node itself has no sibling on that side.

## Why

`search.range` frames a `non_bracket` node by its surrounding siblings, falling back to the parent's sibling when the node has none:

```lua
local first = n:prev_sibling() or n:parent():prev_sibling()
local last  = n:next_sibling() or n:parent():next_sibling()
```

This is correct for languages whose blocks have an explicit closing delimiter token (e.g. Lua's `then ... end`, where the delimiter is a sibling). But **indentation-based languages have no closing token** (Python, GDScript, CoffeeScript, …). A block that is the last child of its parent then has no `next_sibling`, so the fallback grabs the *following statement* — the join range extends over it and swallows it. This currently makes it impossible to support split/join of `:`-introduced indented bodies.

## Change

```lua
local climb = type(non_bracket_node) ~= 'table'
  or non_bracket_node.outer_framing ~= false

local function get_framing_for_non_bracket(n)
  local first = n:prev_sibling()
  local last = n:next_sibling()
  if climb then
    first = first or n:parent():prev_sibling()
    last = last or n:parent():next_sibling()
  end
  return first, last
end
```

With `outer_framing = false`, a missing side uses the node's own range instead of the parent's sibling.

## Backward compatibility

Purely additive and opt-in — `outer_framing` defaults to `true`, so framing is byte-for-byte unchanged for every existing preset. Verified against an existing `non_bracket` language (Lua, round-trips with a following statement intact) and bracket presets (Python lists/dicts).

## Example

A `non_bracket` block preset with `outer_framing = false` on Python's `block`:

Before (join swallows the next statement):

```python
if cond: do_x()return
```

After:

```python
if cond: do_x()
return
```

## Notes

Language-independent — this is the missing piece for split/join of indentation-delimited blocks in general. A companion GDScript preset PR uses it to toggle one-line `if`/`for`/`while`/function bodies, but the flag is useful to any such language preset.

## Tests

The flag needs a configured language to exercise through the test harness; its behavior is covered by a later GDScript preset modification PR (which needs the original GDScript template first), which uses `outer_framing = false` for statement bodies. I can also fold a test in here (e.g. demonstrating it on Python's `block`) if preferred.